### PR TITLE
Demo building - build url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:focal
 
-RUN apt-get update && apt-get install --yes nginx
+RUN apt-get update && apt-get install --yes gettext-base nginx
 
 # Copy over files
 WORKDIR /srv
-ADD index.html index.html
+ADD entrypoint entrypoint
+ADD index.template index.template
 ADD nginx.conf /etc/nginx/sites-enabled/default
 
 STOPSIGNAL SIGTERM
 
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["./entrypoint"]

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+envsubst < "index.template" > "index.html"
+nginx -g 'daemon off;'

--- a/index.html
+++ b/index.html
@@ -1,8 +1,0 @@
-<html>
-    <head>
-    </head>
-<body>
-    <h1>Demo is building...</h1>
-    <p>If it is not online soon, please check the <a href="https://jenkins.canonical.com/webteam/view/demos/job/start-demo/">Jenkins Job</a> was succesfull</p>
-</body>
-</html>

--- a/index.template
+++ b/index.template
@@ -1,0 +1,9 @@
+<html>
+    <head>
+    </head>
+<body>
+    <h1>Building...</h1>
+    <p>If you are seeing this page, either your demo is still building or something failed.</p>
+    <p>You can check the state of your build <a href="$BUILD_URL">here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
# Done
Allow the possibility of customising the link to the jenkins job when running the image.

# QA
- docker build -t demo-placeholder .
- docker run -ti -p 8080:80 --env BUILD_URL="https://ubuntu.com demo-placeholder"
- check  in localhost:8080 that the link takes you to ubuntu.com